### PR TITLE
#9 - Mitigate performance issues that came from adding more properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,33 +146,31 @@ Note:
 - Members are only polyfilled on the specific web component unless otherwise noted.
 - Members must be overridden on the instance rather than prototype because WebKit has a bug that prevents correct descritpors from being returned using [`Object.getOwnPropertyDescriptor()`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptor) See https://bugs.webkit.org/show_bug.cgi?id=49739 for more info.
 
-
-
 ## Polyfilled
 
 These are members which are already polyfilled.
 
 ### Properties
 
-#### Element
-
 - `Element.innerHTML`
-
-#### Node
-
+- `Element.outerHTML` - Only the getter is polyfilled.
 - `Node.childNodes`
 - `Node.firstChild`
 - `Node.lastChild`
+- `Node.nextSibling`
+- `Node.nodeValue` - Doesn't need polyfilling because its return value is `null` for all element nodes.
+- `Node.parentElement`
 - `Node.parentNode`
+- `Node.previousSibling`
 - `Node.textContent`
-
-#### ParentNode
-
+- `NonDocumentTypeChildNode.nextElementSibling`
+- `NonDocumentTypeChildNode.previousElementSibling`
+- `ParentNode.childElementCount`
 - `ParentNode.children`
+- `ParentNode.firstElementChild`
+- `ParentNode.lastElementChild`
 
 ### Methods
-
-#### Node
 
 - `Node.appendChild()`
 - `Node.hasChildNodes()`
@@ -180,69 +178,34 @@ These are members which are already polyfilled.
 - `Node.removeChild()`
 - `Node.replaceChild()`
 
-
-
-## Probably
-
-These are members which are not yet polyfilled but are planned to be.
-
-### Properties
-
-#### ParentNode
-
-- `ParentNode.childElementCount`
-- `ParentNode.firstElementChild`
-- `ParentNode.lastElementChild`
-
-
-
 ## Maybe
 
-These are members which are not yet polyfilled but are up for discussion.
+These are members which are not yet polyfilled for a few reasons:
+
+- They'd probably have to be polyfilled for all elements, not just the host.
+- They may not behave as expected causing confusion.
+- If only part of the finding methods are polyfilled, not polyfilling some may cause confusion.
 
 ### Properties
-
-#### Element
 
 - `Element.id`
 
-#### NonDocumentTypeChildNode
-
-- `NonDocumentTypeChildNode.nextElementSibling`
-- `NonDocumentTypeChildNode.previousElementSibling`
-
-#### Node
-
-- `Node.nodeValue`
-- `Node.nextSibling`
-- `Node.nodeValue`
-- `Node.parentElement`
-- `Node.previousSibling`
-
 ### Methods
 
-#### Element
-
+- `Document.getElementById()`
 - `Element.getElementsByClassName()`
 - `Element.getElementsByTagName()`
 - `Element.getElementsByTagNameNS()`
-
-#### Node
-
-- `Node.cloneNode()`
+- `Element.querySelector()`
+- `Element.querySelectorAll()`
 - `Node.compareDocumentPosition()`
 - `Node.contains()`
-- `Node.normalize()`
-
-
 
 ## Unlikely
 
-These are members which are not polyfilled and probably never will be because it's likely not necessary.
+These are members which are not polyfilled because it's likely not necessary.
 
 ### Properties
-
-#### Element
 
 - `Element.accessKey`
 - `Element.attributes`
@@ -250,17 +213,12 @@ These are members which are not polyfilled and probably never will be because it
 - `Element.className`
 - `Element.namespaceURI`
 - `Element.tagName`
-
-#### Node
-
 - `Node.baseURI`
 - `Node.nodeName`
 - `Node.nodeType`
 - `Node.ownerDocument`
 
 ### Methods
-
-#### Element
 
 - `Element.getAttribute()`
 - `Element.getAttributeNS()`
@@ -269,24 +227,18 @@ These are members which are not polyfilled and probably never will be because it
 - `Element.hasAttribute()`
 - `Element.hasAttributeNS()`
 - `Element.hasAttributes()`
-- `Element.querySelector()`
-- `Element.querySelectorAll()`
 - `Element.releasePointerCapture()`
 - `Element.removeAttribute()`
 - `Element.removeAttributeNS()`
 - `Element.setAttribute()`
 - `Element.setAttributeNS()`
 - `Element.setPointerCapture()`
-
-#### EventTarget
-
 - `EventTarget.addEventListener()`
 - `EventTarget.dispatchEvent()`
 - `EventTarget.removeEventListener()`
-
-#### Node
-
+- `Node.cloneNode()`
 - `Node.isDefaultNamespace()`
 - `Node.isEqualNode()`
 - `Node.lookupNamespaceURI()`
 - `Node.lookupPrefix()`
+- `Node.normalize()`

--- a/src/polyfill.js
+++ b/src/polyfill.js
@@ -5,10 +5,75 @@ import prop from './internal/prop';
 // Helpers.
 
 function applyParentNode (node, parent) {
+  prop(node, 'parentElement', {
+    configurable: true,
+    get () {
+      return parent.nodeType === 1 ? parent : null;
+    }
+  });
+
   prop(node, 'parentNode', {
     configurable: true,
-    get: function () {
+    get () {
       return parent;
+    }
+  });
+
+  prop(node, 'nextSibling', {
+    configurable: true,
+    get () {
+      let index;
+      const parChs = parent.childNodes;
+      const parChsLen = parChs.length;
+      for (let a = 0; a < parChsLen; a++) {
+        if (parChs[a] === node) {
+          index = a;
+          continue;
+        }
+      }
+      return typeof index === 'number' ? parChs[index + 1] : null;
+    }
+  });
+
+  prop(node, 'nextElementSibling', {
+    configurable: true,
+    get () {
+      let next;
+      while ((next = this.nextSibling)) {
+        if (next.nodeType === 1) {
+          return next;
+        }
+      }
+      return null;
+    }
+  });
+
+  prop(node, 'previousSibling', {
+    configurable: true,
+    get () {
+      let index;
+      const parChs = parent.childNodes;
+      const parChsLen = parChs.length;
+      for (let a = 0; a < parChsLen; a++) {
+        if (parChs[a] === node) {
+          index = a;
+          continue;
+        }
+      }
+      return typeof index === 'number' ? parChs[index - 1] : null;
+    }
+  });
+
+  prop(node, 'previousElementSibling', {
+    configurable: true,
+    get () {
+      let prev;
+      while ((prev = this.previousSibling)) {
+        if (prev.nodeType === 1) {
+          return prev;
+        }
+      }
+      return null;
     }
   });
 }

--- a/test/unit.js
+++ b/test/unit.js
@@ -232,7 +232,45 @@ describe('skatejs-named-slots', function () {
       expect(host.outerHTML).to.equal('<div><div></div></div>');
     });
 
-    it('parentNode', function () {
+    it('nextSibling, previousSibling', function () {
+      const ch1 = document.createElement('div');
+      const ch2 = document.createElement('div');
+
+      // So they can get distributed.
+      ch1.setAttribute('slot', 'slot1');
+      ch2.setAttribute('slot', 'slot2');
+
+      // Create separate slots so each node can go into a separate one.
+      shadow.innerHTML = '<div slot-name="slot1"></div><div slot-name="slot2"></div>';
+
+      // Distribute.
+      host.appendChild(ch1);
+      host.appendChild(ch2);
+
+      expect(ch1.nextSibling).to.equal(ch2);
+      expect(ch2.previousSibling).to.equal(ch1);
+    });
+
+    it('nextElementSibling, previousElementSibling', function () {
+      const ch1 = document.createElement('div');
+      const ch2 = document.createElement('div');
+
+      // So they can get distributed.
+      ch1.setAttribute('slot', 'slot1');
+      ch2.setAttribute('slot', 'slot2');
+
+      // Create separate slots so each node can go into a separate one.
+      shadow.innerHTML = '<div slot-name="slot1"></div><div slot-name="slot2"></div>';
+
+      // Distribute.
+      host.appendChild(ch1);
+      host.appendChild(ch2);
+
+      expect(ch1.nextElementSibling).to.equal(ch2);
+      expect(ch2.previousElementSibling).to.equal(ch1);
+    });
+
+    it('parentElement, parentNode', function () {
       const childNode = document.createElement('div');
 
       host.appendChild(childNode);
@@ -241,6 +279,7 @@ describe('skatejs-named-slots', function () {
       expect(slot.childNodes[0]).to.equal(childNode);
 
       // And this will confirm appendChild has set parentNode.
+      expect(childNode.parentElement).to.equal(host);
       expect(childNode.parentNode).to.equal(host);
 
       // We ensure that removeChild cleans up the parentNode.


### PR DESCRIPTION
_Merge after #10._

Performance imporovements by using prototypes where possible and only falling back to patching instances for browsers that don't allow you to `getOwnPropertyDescriptors()` for native prototypes.

Performance is almost doubled without touching native much. See perf tests.
