### PR TITLE
On Chrome 38, Object.getOwnPropertyDescriptor(window.Node.prototype, …

### DIFF
--- a/src/util/can-patch-native-accessors.js
+++ b/src/util/can-patch-native-accessors.js
@@ -1,3 +1,3 @@
 // Any code referring to this is because it has to work around this bug in
 // WebKit: https://bugs.webkit.org/show_bug.cgi?id=49739
-export default !!Object.getOwnPropertyDescriptor(window.Node.prototype, 'parentNode').get;
+export default !!(Object.getOwnPropertyDescriptor(window.Node.prototype, 'parentNode') && Object.getOwnPropertyDescriptor(window.Node.prototype, 'parentNode').get);


### PR DESCRIPTION
…'parentNode') is undefined
