### PR TITLE
fix #60 - writable for polyfilled properties

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -749,6 +749,8 @@ if (!('attachShadow' in document.createElement('div'))) {
 
     // All properties should be configurable.
     memberProperty.configurable = true;
+    // Applying to the data properties only since we can't have writable accessor properties
+    !(memberProperty.hasOwnProperty('get') || memberProperty.hasOwnProperty('set')) && (memberProperty.writable = true);
 
     // Polyfill as much as we can and work around WebKit in other areas.
     if (canPatchNativeAccessors || polyfillAtRuntime.indexOf(memberName) === -1) {

--- a/src/index.js
+++ b/src/index.js
@@ -750,7 +750,9 @@ if (!('attachShadow' in document.createElement('div'))) {
     // All properties should be configurable.
     memberProperty.configurable = true;
     // Applying to the data properties only since we can't have writable accessor properties
-    !(memberProperty.hasOwnProperty('get') || memberProperty.hasOwnProperty('set')) && (memberProperty.writable = true);
+    if (memberProperty.hasOwnProperty('value')) {
+      memberProperty.writable = true
+    }
 
     // Polyfill as much as we can and work around WebKit in other areas.
     if (canPatchNativeAccessors || polyfillAtRuntime.indexOf(memberName) === -1) {

--- a/test/unit/shadow/polyfill.js
+++ b/test/unit/shadow/polyfill.js
@@ -53,6 +53,13 @@ describe('shadow/polyfill', function () {
     });
   }
 
+  it('polyfilled properties with value should be writable', function() {
+    let elem = create('div');
+    
+    expect(elem.removeEventListener).not.to.equal("");
+    elem.removeEventListener = "";
+    expect(elem.removeEventListener).to.equal("");
+  });
 
   describe('api', function () {
     let host, root;


### PR DESCRIPTION
The problem is connected to the https://github.com/skatejs/named-slots/issues/41
Since jQuery uses assignment for removeEventListener in tests
