### PR TITLE
chore: enable Travis & Saucelabs & linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,3 @@ before_script:
 script:
 - npm run lint
 - if [ "${TRAVIS_SECURE_ENV_VARS}" = "true" ]; then npm test -- --saucelabs; else npm test -- --browsers Firefox; fi
-env:
-  global:
-    - SAUCE_TESTNAME="skatejs-named-slots"
-    - SAUCE_USERNAME="skatejs-named-slots"
-    - secure:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# named-slots
+# named-slots [![Build Status](https://travis-ci.org/skatejs/named-slots.svg?branch=master)](https://travis-ci.org/skatejs/named-slots)
 
 A polygap (partial polyfill) for the Shadow DOM Named Slot API.
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "lib/index.js",
   "jsnext:main": "src/index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "lint": "gulp lint",
+    "test": "gulp test",
     "build": "gulp build"
   },
   "repository": {

--- a/src/util/get-escaped-text-content.js
+++ b/src/util/get-escaped-text-content.js
@@ -4,7 +4,7 @@
  * @returns {string}
  */
 export default function getEscapedTextContent (textNode) {
-  return textNode.textContent.replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
+  return textNode.textContent.replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
 }

--- a/test/unit/slot/distribution.js
+++ b/test/unit/slot/distribution.js
@@ -3,6 +3,9 @@ import create from '../lib/create';
 
 describe('slot/distribution', function () {
   let slot;
+  let host;
+  let root;
+  let parent;
 
   beforeEach(function () {
     host = document.createElement('div');


### PR DESCRIPTION
This enables the Travis build & Saucelabs tests with it.
Currently some of the browsers supported by SkateJS fail the tests (Internet Explorer 9 & 10, Opera).
Possibly because of some missing poly fills - this should be fixed further down the line.

PTAL @treshugart 
