### PR TITLE
Broken test for fallback content

### DIFF
--- a/test/unit/slot/fallback-content.js
+++ b/test/unit/slot/fallback-content.js
@@ -79,4 +79,58 @@ describe('fallback-content', function () {
       });
     });
   });
+
+  describe('with slot/fallback content assigned by innerHTML', function () {
+    let fallback;
+
+    beforeEach(function () {
+      root.innerHTML = "<slot><div></div></slot>"
+      slot = root.firstChild
+    });
+
+    it('should have fallback nodes', function () {
+      expect(slot.childNodes.length).to.equal(1);
+      expect(slot.childNodes[0]).to.equal(fallback);
+    });
+
+    it('should have no assigned nodes', function () {
+      expect(slot.____assignedNodes.length).to.equal(0);
+      expect(slot.assignedNodes().length).to.equal(0);
+    });
+
+    it('should be in a fallback state', function () {
+      expect(slot.____isInFallbackMode).to.equal(true);
+    });
+
+    describe('when assigned nodes', function () {
+      let newNode;
+
+      beforeEach(function () {
+        newNode = create('div');
+        host.appendChild(newNode);
+      });
+
+      it('should contain assigned nodes', function () {
+        expect(slot.assignedNodes()[0]).to.equal(newNode);
+      });
+
+      it('should not be in a fallback state', function () {
+        expect(slot.____isInFallbackMode).to.equal(false);
+      });
+
+      describe('are removed', function () {
+        beforeEach(function () {
+          host.removeChild(newNode);
+        });
+
+        it('should not contain the assigned nodes', function () {
+          expect(slot.assignedNodes().length).to.equal(0);
+        });
+
+        it('should return to a fallback state', function () {
+          expect(slot.____isInFallbackMode).to.equal(true);
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
Here is a test demonstrating the broken fallback content bug.  By using innerHTML to insert the shadow root's content like the example in the Readme the fallback content is not properly added to the childNodes of the slot.  I'm currently not sure of the proper fix but hopefully this helps pinpoint the issue.
