### PR TITLE
Fix nested fallback content when set by innerHTML

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -648,13 +648,14 @@ const members = {
         this.removeChild(this.firstChild);
       }
 
+      // when we are doing this: root.innerHTML = "<slot><div></div></slot>";
+      // slot.__childNodes is out of sync with slot.childNodes.
+      // to fix it we have to manually remove and insert them
+      const slots = parsed.querySelectorAll('slot');
+      forEach.call(slots, slot => {syncSlotChildNodes(slot);});
+
       while (parsed.hasChildNodes()) {
         const firstChild = parsed.firstChild;
-
-        // when we are doing this: root.innerHTML = "<slot><div></div></slot>";
-        // slot.__childNodes is out of sync with slot.childNodes.
-        // to fix it we have to manually remove and insert them
-        syncSlotChildNodes(firstChild);
 
         // When we polyfill everything on HTMLElement.prototype, we overwrite
         // properties. This makes it so that parentNode reports null even though

--- a/test/unit/slot/fallback-content.js
+++ b/test/unit/slot/fallback-content.js
@@ -84,8 +84,8 @@ describe('fallback-content', function () {
     let fallback;
 
     beforeEach(function () {
-      root.innerHTML = '<slot><div></div></slot>';
-      slot = root.firstChild;
+      root.innerHTML = '<div><slot><div></div></slot></div>';
+      slot = root.firstChild.firstChild;
       fallback = slot.firstChild;
     });
 


### PR DESCRIPTION
If the slots were not top level they were being skipped by the previous fix. Provided a potential new fix and updated test to reflect nested scenario.
