### PR TITLE
fix: use different weakmap poly fill

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "custom-event-polyfill": "joscha/custom-event-polyfill#de24bd9",
     "debounce": "^1.0.0",
-    "weakmap": "0.0.6"
+    "webcomponents.js": "skatejs/webcomponentsjs#skate-v1"
   },
   "config": {
     "commitizen": {

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ import debounce from 'debounce';
 import getEscapedTextContent from './util/get-escaped-text-content';
 import getCommentNodeOuterHtml from './util/get-comment-node-outer-html';
 import version from './version';
-import WeakMap from 'weakmap';
+import 'webcomponents.js/src/WeakMap/WeakMap.js';
 import 'custom-event-polyfill';
 
 const arrProto = Array.prototype;


### PR DESCRIPTION
The current one fails in IE10+:

```
IE 11.0.0 (Windows 8.1 0.0.0) ERROR
  Unable to get property 'replace' of undefined or null reference
  at /build/lib/polyfills.js:2063 <- webpack:///build/~/weakmap/weakmap.js:39:0
```
