### PR TITLE
#100 - Fix issue where childNodes was undefined.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -571,7 +571,7 @@ const members = {
         return this.__childNodes;
       }
       let childNodes = nodeToChildNodesMap.get(this);
-
+      
       if (!childNodes) {
         nodeToChildNodesMap.set(this, childNodes = makeLikeNodeList([]));
       }
@@ -871,6 +871,7 @@ if (!('attachShadow' in document.createElement('div'))) {
 
       if (nativeDescriptor) {
         Object.defineProperty(elementProto, nativeMemberName, nativeDescriptor);
+        Object.defineProperty(svgProto, nativeMemberName, nativeDescriptor);
       }
 
       if (shouldOverrideInTextNode) {

--- a/test/unit/dom/dom.js
+++ b/test/unit/dom/dom.js
@@ -2,6 +2,12 @@ import create from '../../lib/create';
 import hasAllAttributes from '../../lib/has-all-attributes';
 import canPatchNativeAccessors from '../../../src/util/can-patch-native-accessors';
 
+function expectToBeLikeNodeList(val) {
+  expect(val).not.to.equal(undefined, 'like NodeList: undefined');
+  expect(val.length).to.be.a('number', 'like NodeList: length not a number');
+  expect(val.item).to.be.a('function', 'like NodeList: item not a function');
+}
+
 describe('skatejs-named-slots dom', function () {
   let host, root, slot, div1, div2, div3, div4, div5;
 
@@ -1044,6 +1050,7 @@ describe('skatejs-named-slots dom', function () {
       div.shadowRoot.appendChild(document.createElement('slot'));
       div.appendChild(svg);
       expect(svg.parentNode).to.equal(div);
+      expectToBeLikeNodeList(svg.childNodes);
     });
   });
 });


### PR DESCRIPTION
This is because we weren't adding native descriptors to the prototype to access from overridden
descriptors.

FIxes #100.
