### PR TITLE
feat: Add support for native v0 custom elements to behave like v1.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,30 +1,3 @@
 {
-  "rules": {
-    "indent": [2, 2],
-    "quotes": [2, "single"],
-    "linebreak-style": [2, "unix"],
-    "semi": [2, "always"],
-    "no-unused-vars": [2, {"varsIgnorePattern": "^vdom$"}]
-  },
-  "env": {
-    "es6": true,
-    "node": true,
-    "browser": true
-  },
-  "ecmaFeatures": {
-    "jsx": true,
-    "modules": true
-  },
-  "plugins": [
-    "react"
-  ],
-  "extends": "eslint:recommended",
-  "globals": {
-    "afterEach": true,
-    "assert": true,
-    "beforeEach": true,
-    "describe": true,
-    "expect": true,
-    "it": true
-  }
+  "extends": "./node_modules/skatejs-build/.eslintrc"
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # named-slots [![Build Status](https://travis-ci.org/skatejs/named-slots.svg?branch=master)](https://travis-ci.org/skatejs/named-slots)
 
-A polygap (partial polyfill) for the Shadow DOM Named Slot API.
+A polygap (partial polyfill) for the Shadow DOM Named Slot API. Also polyfills native v0 to behave like v1 with minimal overrides. 
 
 
 
@@ -9,6 +9,7 @@ A polygap (partial polyfill) for the Shadow DOM Named Slot API.
 - You want to expose a named-slot style public API to your web component consumers
 - You don't want to resort to massive, or outdated polyfills
 - You don't want to wait for browser adoption
+- Uses native v0 where it can
 - You don't need allthethings in the [Shadow DOM spec](http://w3c.github.io/webcomponents/spec/shadow/)
 - You want interopaberability with React, jQuery and other libraries that don't care about your implementation details
 - You want something that is performant
@@ -215,6 +216,21 @@ These are members which are not polyfilled because it's likely not necessary.
 - `Node.lookupPrefix()`
 - `Node.normalize()`
 - `Node.removeEventListener()`
+
+
+
+### V0 overrides
+
+There are minimal overrides for the native Shadow DOM implementations so that they behave like v1.
+
+- `Element.innerHTML`
+- `HTMLContentElement.name`
+- `HTMLContentElement.assignedNodes()`
+- `HTMLContentElement.getAttribute()`
+- `HTMLContentElement.setAttribute()`
+- `HTMLElement.attachShadow()`
+- `Node.assignedSlot`
+- `ShadowRoot.innerHTML`
 
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -554,7 +554,7 @@ const members = {
         return this.__childNodes;
       }
       let childNodes = nodeToChildNodesMap.get(this);
-      
+
       if (!childNodes) {
         nodeToChildNodesMap.set(this, childNodes = makeLikeNodeList([]));
       }
@@ -849,8 +849,14 @@ if (shadowDomV1) {
       const nativeDescriptor = getPropertyDescriptor(elementProto, memberName);
       const nativeTextDescriptor = getPropertyDescriptor(textProto, memberName);
       const nativeCommDescriptor = getPropertyDescriptor(commProto, memberName);
-      const shouldOverrideInTextNode = (memberName in textNode && doNotOverridePropertiesInTextNodes.indexOf(memberName) === -1) || ~defineInTextNodes.indexOf(memberName);
-      const shouldOverrideInCommentNode = (memberName in commNode && doNotOverridePropertiesInCommNodes.indexOf(memberName) === -1) || ~defineInCommNodes.indexOf(memberName);
+      const shouldOverrideInTextNode = (
+        memberName in textNode &&
+        doNotOverridePropertiesInTextNodes.indexOf(memberName) === -1
+      ) || ~defineInTextNodes.indexOf(memberName);
+      const shouldOverrideInCommentNode = (
+        memberName in commNode &&
+        doNotOverridePropertiesInCommNodes.indexOf(memberName) === -1
+      ) || ~defineInCommNodes.indexOf(memberName);
       const nativeMemberName = `__${memberName}`;
 
       Object.defineProperty(elementProto, memberName, memberProperty);

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import { eachChildNode, eachNodeOrFragmentNodes } from './util/each';
+import { shadowDomV0, shadowDomV1 } from './util/support';
 import canPatchNativeAccessors from './util/can-patch-native-accessors';
 import getPropertyDescriptor from './util/get-property-descriptor';
 import debounce from 'debounce';
@@ -8,6 +9,7 @@ import findSlots from './util/find-slots';
 import isRootNode from './util/is-root-node';
 import isSlotNode from './util/is-slot-node';
 import pseudoArrayToArray from './util/pseudo-array-to-array';
+import v0 from './v0';
 import version from './version';
 import 'webcomponents.js/src/WeakMap/WeakMap.js';
 import 'custom-event-polyfill';
@@ -137,26 +139,7 @@ function getSlotNameFromNode(node) {
 }
 
 function slotNodeIntoSlot(slot, node, insertBefore) {
-  // Don't slot nodes that have content but are only whitespace. This is an
-  // anomaly that I don't think the spec deals with.
-  //
-  // The problem is:
-  //
-  // - If you insert HTML with indentation into the page, there will be
-  //   whitespace and if that's inserted it messes with fallback content
-  //   calculation where there is formatting, but no meaningful content, so in
-  //   theory it should fallback. Since you can attach a shadow root after we
-  //   mean to insert an empty text node and have it "count", we can't really
-  //   discard nodes that are considered formatting at the time of attachment.
-  // - You can insert a text node and modify its text content later.
-  //   Incremental DOM seems to do this. Every way I look at it, it seems
-  //   problematic that we should have to screen for content, but I don't seems
-  //   much of a way around it at the moment.
-  if (node.nodeType === 3 && node.textContent && node.textContent.trim().length === 0) {
-    return;
-  }
-
-  // only Text and Element nodes should be slotted
+  // Only Text and Element nodes should be slotted.
   if (slottedNodeTypes.indexOf(node.nodeType) === -1) {
     return;
   }
@@ -838,7 +821,11 @@ const members = {
   },
 };
 
-if (!('attachShadow' in document.createElement('div'))) {
+if (shadowDomV1) {
+  // then we should probably not be loading this
+} else if (shadowDomV0) {
+  v0();
+} else {
   const commProto = Comment.prototype;
   const elementProto = HTMLElement.prototype;
   const svgProto = SVGElement.prototype;

--- a/src/util/find-slots.js
+++ b/src/util/find-slots.js
@@ -1,7 +1,12 @@
+import { shadowDomV0 } from './support';
 import isSlotNode from './is-slot-node';
 
 export default function findSlots(root, slots = []) {
   const { childNodes } = root;
+
+  if (shadowDomV0) {
+    return [...root.querySelectorAll('content')];
+  }
 
   if (!childNodes || root.nodeType !== Node.ELEMENT_NODE) {
     return slots;

--- a/src/util/support.js
+++ b/src/util/support.js
@@ -1,0 +1,3 @@
+const div = document.createElement('div');
+export const shadowDomV0 = !!div.createShadowRoot;
+export const shadowDomV1 = !!div.attachShadow;

--- a/src/v0/index.js
+++ b/src/v0/index.js
@@ -152,8 +152,8 @@ export default () => {
         const slots = {};
         const recordSlots = node => (slots[node.getAttribute && node.getAttribute('slot') || '__default'] = true);
 
-        addedNodes.forEach(recordSlots);
-        removedNodes.forEach(recordSlots);
+        [...addedNodes].forEach(recordSlots);
+        [...removedNodes].forEach(recordSlots);
 
         Object.keys(slots).forEach(slot => {
           const node = slot === '__default' ?

--- a/src/v0/index.js
+++ b/src/v0/index.js
@@ -20,9 +20,8 @@ export default () => {
       return [];
     }
 
-    let chs = host.childNodes;
-    let chsLen = chs.length;
-
+    const chs = host.childNodes;
+    const chsLen = chs.length;
     const filtered = [];
 
     for (let a = 0; a < chsLen; a++) {
@@ -41,15 +40,11 @@ export default () => {
   const shadowRootInnerHTML = Object.getOwnPropertyDescriptor(ShadowRoot.prototype, 'innerHTML');
 
   // We do this so creating a <slot> actually creates a <content>.
-  const filterTagName = name => name === 'slot' ? 'content' : name;
+  const filterTagName = name => (name === 'slot' ? 'content' : name);
   const createElement = document.createElement.bind(document);
   const createElementNS = document.createElementNS.bind(document);
-  document.createElement = function(name, ...args) {
-    return createElement(filterTagName(name), ...args);
-  };
-  document.createElementNS = function(name, ...args) {
-    return createElementNS(filterTagName(name), ...args);
-  };
+  document.createElement = (name, ...args) => createElement(filterTagName(name), ...args);
+  document.createElementNS = (name, ...args) => createElementNS(filterTagName(name), ...args);
 
   // Override innerHTML to turn slot nodes into content nodes.
   function replaceSlotsWithContents(node) {
@@ -80,7 +75,7 @@ export default () => {
   Object.defineProperty(Element.prototype, 'innerHTML', {
     configurable: true,
     get: elementInnerHTML.get,
-    set (html) {
+    set(html) {
       elementInnerHTML.set.call(this, html);
       replaceSlotsWithContents(this);
     },
@@ -88,7 +83,7 @@ export default () => {
   Object.defineProperty(ShadowRoot.prototype, 'innerHTML', {
     configurable: true,
     get: shadowRootInnerHTML.get,
-    set (html) {
+    set(html) {
       shadowRootInnerHTML.set.call(this, html);
       replaceSlotsWithContents(this);
     },
@@ -124,7 +119,7 @@ export default () => {
 
   // Just proxy createShadowRoot() because there's no such thing as closed
   // shadow trees in v0.
-  HTMLElement.prototype.attachShadow = function({ mode } = {}) {
+  HTMLElement.prototype.attachShadow = function attachShadow({ mode } = {}) {
     // In v1 you must specify a mode.
     if (mode !== 'closed' && mode !== 'open') {
       throw new Error('You must specify { mode } as "open" or "closed" to attachShadow().');
@@ -143,7 +138,7 @@ export default () => {
 
     // For some reason this wasn't being reported as set, but it seems to work
     // in dev tools.
-    Object.defineProperty(sr, 'parentNode', { 
+    Object.defineProperty(sr, 'parentNode', {
       get: () => this,
     });
 
@@ -155,14 +150,14 @@ export default () => {
       muts.forEach(mut => {
         const { addedNodes, removedNodes } = mut;
         const slots = {};
-        const recordSlots = node => slots[node.getAttribute && node.getAttribute('slot') || '__default'] = true;
+        const recordSlots = node => (slots[node.getAttribute && node.getAttribute('slot') || '__default'] = true);
 
         addedNodes.forEach(recordSlots);
         removedNodes.forEach(recordSlots);
 
         Object.keys(slots).forEach(slot => {
-          const node = slot === '__default' ? 
-            root.querySelector('content:not([name])') || root.querySelector('content[name=""]') : 
+          const node = slot === '__default' ?
+            root.querySelector('content:not([name])') || root.querySelector('content[name=""]') :
             root.querySelector(`content[name="${slot}"]`);
 
           if (node) {
@@ -176,7 +171,7 @@ export default () => {
     });
     mo.observe(this, { childList: true });
 
-    return this[$shadowRoot] = sr;
+    return (this[$shadowRoot] = sr);
   };
 
 
@@ -193,7 +188,7 @@ export default () => {
   // By default, getDistributedNodes() returns a flattened tree (no <slot>
   // nodes). That means we get native { deep } but we have to manually do the
   // opposite.
-  HTMLContentElement.prototype.assignedNodes = function({ deep } = {}) {
+  HTMLContentElement.prototype.assignedNodes = function assignedNodes({ deep } = {}) {
     const cnodes = [];
     const dnodes = deep ? this.getDistributedNodes() : getAssignedNodes(this);
 
@@ -209,7 +204,7 @@ export default () => {
     return cnodes;
   };
 
-  HTMLContentElement.prototype.getAttribute = function(name) {
+  HTMLContentElement.prototype.getAttribute = function overriddenGetAttribute(name) {
     if (name === 'name') {
       const select = getAttribute.call(this, 'select');
       return select ? select.match(/\[slot=['"]?(.*?)['"]?\]/)[1] : null;
@@ -217,7 +212,7 @@ export default () => {
     return getAttribute.call(this, name);
   };
 
-  HTMLContentElement.prototype.setAttribute = function(name, value) {
+  HTMLContentElement.prototype.setAttribute = function overriddenSetAttribute(name, value) {
     if (name === 'name') {
       name = 'select';
       value = `[slot='${value}']`;

--- a/src/v0/index.js
+++ b/src/v0/index.js
@@ -51,7 +51,7 @@ export default () => {
     const tree = document.createTreeWalker(node, NodeFilter.SHOW_ELEMENT);
     const repl = [];
 
-    // Walk the tree and record nods that need replacing.
+    // Walk the tree and record nodes that need replacing.
     while (tree.nextNode()) {
       const { currentNode } = tree;
       if (currentNode.tagName === 'SLOT') {

--- a/src/v0/index.js
+++ b/src/v0/index.js
@@ -1,0 +1,227 @@
+import 'custom-event-polyfill';
+
+const $shadowRoot = '__shadowRoot';
+
+export default () => {
+  // Returns the assigned nodes (unflattened) for a <content> node.
+  const getAssignedNodes = node => {
+    const slot = node.getAttribute('name');
+
+    let host = node;
+    while (host) {
+      const sr = host[$shadowRoot];
+      if (sr && sr.contains(node)) {
+        break;
+      }
+      host = host.parentNode;
+    }
+
+    if (!host) {
+      return [];
+    }
+
+    let chs = host.childNodes;
+    let chsLen = chs.length;
+
+    const filtered = [];
+
+    for (let a = 0; a < chsLen; a++) {
+      const ch = chs[a];
+      const chSlot = ch.getAttribute ? ch.getAttribute('slot') : null;
+      if (slot === chSlot) {
+        filtered.push(ch);
+      }
+    }
+
+    return filtered;
+  };
+
+  const { getAttribute, setAttribute } = HTMLElement.prototype;
+  const elementInnerHTML = Object.getOwnPropertyDescriptor(Element.prototype, 'innerHTML');
+  const shadowRootInnerHTML = Object.getOwnPropertyDescriptor(ShadowRoot.prototype, 'innerHTML');
+
+  // We do this so creating a <slot> actually creates a <content>.
+  const filterTagName = name => name === 'slot' ? 'content' : name;
+  const createElement = document.createElement.bind(document);
+  const createElementNS = document.createElementNS.bind(document);
+  document.createElement = function(name, ...args) {
+    return createElement(filterTagName(name), ...args);
+  };
+  document.createElementNS = function(name, ...args) {
+    return createElementNS(filterTagName(name), ...args);
+  };
+
+  // Override innerHTML to turn slot nodes into content nodes.
+  function replaceSlotsWithContents(node) {
+    const tree = document.createTreeWalker(node, NodeFilter.SHOW_ELEMENT);
+    const repl = [];
+
+    // Walk the tree and record nods that need replacing.
+    while (tree.nextNode()) {
+      const { currentNode } = tree;
+      if (currentNode.tagName === 'SLOT') {
+        repl.push(currentNode);
+      }
+    }
+
+    repl.forEach(fake => {
+      const name = fake.getAttribute('name');
+      const real = document.createElement('slot');
+      if (name) {
+        real.setAttribute('name', name);
+      }
+
+      fake.parentNode.replaceChild(real, fake);
+      while (fake.hasChildNodes()) {
+        real.appendChild(fake.firstChild);
+      }
+    });
+  }
+  Object.defineProperty(Element.prototype, 'innerHTML', {
+    configurable: true,
+    get: elementInnerHTML.get,
+    set (html) {
+      elementInnerHTML.set.call(this, html);
+      replaceSlotsWithContents(this);
+    },
+  });
+  Object.defineProperty(ShadowRoot.prototype, 'innerHTML', {
+    configurable: true,
+    get: shadowRootInnerHTML.get,
+    set (html) {
+      shadowRootInnerHTML.set.call(this, html);
+      replaceSlotsWithContents(this);
+    },
+  });
+
+
+  // Node
+  // ----
+
+  Object.defineProperty(Node.prototype, 'assignedSlot', {
+    get() {
+      const { parentNode } = this;
+      if (parentNode) {
+        const { shadowRoot } = parentNode;
+
+        // If { mode } is "closed", always return `null`.
+        if (!shadowRoot) {
+          return null;
+        }
+
+        const contents = shadowRoot.querySelectorAll('content');
+        for (let a = 0; a < contents.length; a++) {
+          const content = contents[a];
+          if (content.assignedNodes().indexOf(this) > -1) {
+            return content;
+          }
+        }
+      }
+      return null;
+    },
+  });
+
+
+  // Just proxy createShadowRoot() because there's no such thing as closed
+  // shadow trees in v0.
+  HTMLElement.prototype.attachShadow = function({ mode } = {}) {
+    // In v1 you must specify a mode.
+    if (mode !== 'closed' && mode !== 'open') {
+      throw new Error('You must specify { mode } as "open" or "closed" to attachShadow().');
+    }
+
+    // Proxy native v0.
+    const sr = this.createShadowRoot();
+
+    // In v0 it always defines the shadowRoot property so we must undefine it.
+    if (mode === 'closed') {
+      Object.defineProperty(this, 'shadowRoot', {
+        configurable: true,
+        get: () => null,
+      });
+    }
+
+    // For some reason this wasn't being reported as set, but it seems to work
+    // in dev tools.
+    Object.defineProperty(sr, 'parentNode', { 
+      get: () => this,
+    });
+
+    // Add a MutationObserver to trigger slot change events when the element
+    // is mutated. We only need to listen to the childList because we only care
+    // about light DOM.
+    const mo = new MutationObserver(muts => {
+      const root = this[$shadowRoot];
+      muts.forEach(mut => {
+        const { addedNodes, removedNodes } = mut;
+        const slots = {};
+        const recordSlots = node => slots[node.getAttribute && node.getAttribute('slot') || '__default'] = true;
+
+        addedNodes.forEach(recordSlots);
+        removedNodes.forEach(recordSlots);
+
+        Object.keys(slots).forEach(slot => {
+          const node = slot === '__default' ? 
+            root.querySelector('content:not([name])') || root.querySelector('content[name=""]') : 
+            root.querySelector(`content[name="${slot}"]`);
+
+          if (node) {
+            node.dispatchEvent(new CustomEvent('slotchange', {
+              bubbles: false,
+              cancelable: false,
+            }));
+          }
+        });
+      });
+    });
+    mo.observe(this, { childList: true });
+
+    return this[$shadowRoot] = sr;
+  };
+
+
+  // Make like the <slot> name property.
+  Object.defineProperty(HTMLContentElement.prototype, 'name', {
+    get() {
+      return this.getAttribute('name');
+    },
+    set(name) {
+      return this.setAttribute('name', name);
+    },
+  });
+
+  // By default, getDistributedNodes() returns a flattened tree (no <slot>
+  // nodes). That means we get native { deep } but we have to manually do the
+  // opposite.
+  HTMLContentElement.prototype.assignedNodes = function({ deep } = {}) {
+    const cnodes = [];
+    const dnodes = deep ? this.getDistributedNodes() : getAssignedNodes(this);
+
+    // Regardless of how we get the nodes, we must ensure we're only given text
+    // nodes or element nodes.
+    for (let a = 0; a < dnodes.length; a++) {
+      const dnode = dnodes[a];
+      const dtype = dnode.nodeType;
+      if (dtype === Node.ELEMENT_NODE || dtype === Node.TEXT_NODE) {
+        cnodes.push(dnode);
+      }
+    }
+    return cnodes;
+  };
+
+  HTMLContentElement.prototype.getAttribute = function(name) {
+    if (name === 'name') {
+      const select = getAttribute.call(this, 'select');
+      return select ? select.match(/\[slot=['"]?(.*?)['"]?\]/)[1] : null;
+    }
+    return getAttribute.call(this, name);
+  };
+
+  HTMLContentElement.prototype.setAttribute = function(name, value) {
+    if (name === 'name') {
+      name = 'select';
+      value = `[slot='${value}']`;
+    }
+    return setAttribute.call(this, name, value);
+  };
+};

--- a/src/v0/index.js
+++ b/src/v0/index.js
@@ -152,8 +152,19 @@ export default () => {
         const slots = {};
         const recordSlots = node => (slots[node.getAttribute && node.getAttribute('slot') || '__default'] = true);
 
-        [...addedNodes].forEach(recordSlots);
-        [...removedNodes].forEach(recordSlots);
+        if (addedNodes) {
+          const addedNodesLen = addedNodes.length;
+          for (let a = 0; a < addedNodesLen; a++) {
+            recordSlots(addedNodes[a]);
+          }
+        }
+
+        if (removedNodes) {
+          const removedNodesLen = removedNodes.length;
+          for (let a = 0; a < removedNodesLen; a++) {
+            recordSlots(removedNodes[a]);
+          }
+        }
 
         Object.keys(slots).forEach(slot => {
           const node = slot === '__default' ?

--- a/test/perf.js
+++ b/test/perf.js
@@ -11,7 +11,7 @@ describe('add / remove', () => {
     el.removeChild(ch);
   }
 
-  function fn_native(elem) {
+  function fnNative(elem) {
     const ch = div();
     const el = elem;
     el.__appendChild(ch);
@@ -21,7 +21,7 @@ describe('add / remove', () => {
 
   benchmark(() => {
     const elem = div();
-    fn_native(elem);
+    fnNative(elem);
   }).then((opsPerSec) => {
     console.log('native: ', opsPerSec);
   });

--- a/test/unit/dom/appendChild.js
+++ b/test/unit/dom/appendChild.js
@@ -47,8 +47,8 @@ describe('dom: appendChild', () => {
 
       it('should return an appended document fragment', () => {
         const appended = document.createDocumentFragment();
-        const div = document.createElement('div');
-        appended.appendChild(div);
+        const div2 = document.createElement('div');
+        appended.appendChild(div2);
         const changedElem = elem.appendChild(appended);
         expect(changedElem).not.to.equal(undefined);
         expect(changedElem).to.equal(appended);

--- a/test/unit/dom/childElementCount.js
+++ b/test/unit/dom/childElementCount.js
@@ -1,5 +1,3 @@
-import canPatchNativeAccessors from '../../../src/util/can-patch-native-accessors';
-
 describe('dom: childElementCount', () => {
   function runTests(type) {
     describe(`${type}: `, () => {
@@ -38,67 +36,41 @@ describe('dom: childElementCount', () => {
       it('should return correct number of child nodes', () => {
         numbers.forEach(num => {
           expect(elem.childElementCount).to.equal(num);
-          if (type !== 'host' && canPatchNativeAccessors) {
-            expect(elem.__childElementCount).to.equal(num);
-          }
           elem.appendChild(document.createElement('div'));
         });
 
         numbers.reverse().forEach(num => {
           elem.removeChild(elem.lastChild);
           expect(elem.childElementCount).to.equal(num);
-          if (canPatchNativeAccessors && type !== 'host') {
-            expect(elem.__childElementCount).to.equal(num);
-          }
         });
       });
 
       it('should not count text nodes', () => {
         elem.appendChild(document.createTextNode('text'));
         expect(elem.childElementCount).to.equal(0);
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__childElementCount).to.equal(0);
-        }
+
         elem.appendChild(document.createTextNode('text'));
         expect(elem.childElementCount).to.equal(0);
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__childElementCount).to.equal(0);
-        }
 
         elem.removeChild(elem.lastChild);
         expect(elem.childElementCount).to.equal(0);
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__childElementCount).to.equal(0);
-        }
+
         elem.removeChild(elem.lastChild);
         expect(elem.childElementCount).to.equal(0);
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__childElementCount).to.equal(0);
-        }
       });
 
       it('should not count comment nodes', () => {
         elem.appendChild(document.createComment('comment'));
         expect(elem.childElementCount).to.equal(0);
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__childElementCount).to.equal(0);
-        }
+
         elem.appendChild(document.createComment('comment'));
         expect(elem.childElementCount).to.equal(0);
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__childElementCount).to.equal(0);
-        }
 
         elem.removeChild(elem.lastChild);
         expect(elem.childElementCount).to.equal(0);
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__childElementCount).to.equal(0);
-        }
+
         elem.removeChild(elem.lastChild);
         expect(elem.childElementCount).to.equal(0);
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__childElementCount).to.equal(0);
-        }
       });
     });
   }

--- a/test/unit/dom/childNodes.js
+++ b/test/unit/dom/childNodes.js
@@ -1,5 +1,3 @@
-import canPatchNativeAccessors from '../../../src/util/can-patch-native-accessors';
-
 describe('dom: childNodes', () => {
   function runTests(type) {
     describe(`${type}: `, () => {
@@ -38,67 +36,41 @@ describe('dom: childNodes', () => {
       it('should return correct number of child nodes', () => {
         numbers.forEach(num => {
           expect(elem.childNodes.length).to.equal(num);
-          if (canPatchNativeAccessors && type !== 'host') {
-            expect(elem.__childNodes.length).to.equal(num);
-          }
           elem.appendChild(document.createElement('div'));
         });
 
         numbers.reverse().forEach(num => {
           elem.removeChild(elem.lastChild);
           expect(elem.childNodes.length).to.equal(num);
-          if (canPatchNativeAccessors && type !== 'host') {
-            expect(elem.__childNodes.length).to.equal(num);
-          }
         });
       });
 
       it('should count text nodes', () => {
         elem.appendChild(document.createTextNode('text'));
         expect(elem.childNodes.length).to.equal(1);
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__childNodes.length).to.equal(1);
-        }
+
         elem.appendChild(document.createTextNode('text'));
         expect(elem.childNodes.length).to.equal(2);
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__childNodes.length).to.equal(2);
-        }
 
         elem.removeChild(elem.lastChild);
         expect(elem.childNodes.length).to.equal(1);
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__childNodes.length).to.equal(1);
-        }
+
         elem.removeChild(elem.lastChild);
         expect(elem.childNodes.length).to.equal(0);
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__childNodes.length).to.equal(0);
-        }
       });
 
       it('should count comment nodes', () => {
         elem.appendChild(document.createComment('comment'));
         expect(elem.childNodes.length).to.equal(1);
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__childNodes.length).to.equal(1);
-        }
+
         elem.appendChild(document.createComment('comment'));
         expect(elem.childNodes.length).to.equal(2);
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__childNodes.length).to.equal(2);
-        }
 
         elem.removeChild(elem.lastChild);
         expect(elem.childNodes.length).to.equal(1);
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__childNodes.length).to.equal(1);
-        }
+
         elem.removeChild(elem.lastChild);
         expect(elem.childNodes.length).to.equal(0);
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__childNodes.length).to.equal(0);
-        }
       });
 
       it('should be correct nodes if children were appended or inserted', () => {
@@ -113,44 +85,26 @@ describe('dom: childNodes', () => {
         elem.appendChild(node1);
         expect(elem.childNodes[0]).to.equal(node1);
         expect(elem.innerHTML).to.equal('<node1></node1>');
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__childNodes[0]).to.equal(node1);
-        }
 
         elem.appendChild(node2);
         expect(elem.childNodes[1]).to.equal(node2);
         expect(elem.innerHTML).to.equal('<node1></node1><node2></node2>');
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__childNodes[1]).to.equal(node2);
-        }
 
         elem.appendChild(node3);
         expect(elem.childNodes[2]).to.equal(node3);
         expect(elem.innerHTML).to.equal('<node1></node1><node2></node2>text1');
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__childNodes[2]).to.equal(node3);
-        }
 
-        elem.insertBefore(node4);
+        elem.insertBefore(node4, null);
         expect(elem.childNodes[3]).to.equal(node4);
         expect(elem.innerHTML).to.equal('<node1></node1><node2></node2>text1text2');
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__childNodes[3]).to.equal(node4);
-        }
 
-        elem.insertBefore(node5);
+        elem.insertBefore(node5, null);
         expect(elem.childNodes[4]).to.equal(node5);
         expect(elem.innerHTML).to.equal('<node1></node1><node2></node2>text1text2<!--comment1-->');
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__childNodes[4]).to.equal(node5);
-        }
 
-        elem.insertBefore(node6);
+        elem.insertBefore(node6, null);
         expect(elem.childNodes[5]).to.equal(node6);
         expect(elem.innerHTML).to.equal('<node1></node1><node2></node2>text1text2<!--comment1--><!--comment2-->');
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__childNodes[5]).to.equal(node6);
-        }
       });
 
       it('should return correct nodes if children were removed', () => {
@@ -165,17 +119,11 @@ describe('dom: childNodes', () => {
         expect(elem.childNodes.length).to.equal(2);
         expect(elem.childNodes[0]).to.equal(node3);
         expect(elem.innerHTML).to.equal('text1<!--comment1-->');
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__childNodes[0]).to.equal(node3);
-        }
 
         elem.removeChild(elem.firstChild);
         expect(elem.childNodes.length).to.equal(1);
         expect(elem.childNodes[0]).to.equal(node5);
         expect(elem.innerHTML).to.equal('<!--comment1-->');
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__childNodes[0]).to.equal(node5);
-        }
       });
     });
   }

--- a/test/unit/dom/children.js
+++ b/test/unit/dom/children.js
@@ -1,5 +1,3 @@
-import canPatchNativeAccessors from '../../../src/util/can-patch-native-accessors';
-
 describe('dom: children', () => {
   function runTests(type) {
     describe(`${type}: `, () => {
@@ -38,67 +36,41 @@ describe('dom: children', () => {
       it('should return correct number of child nodes', () => {
         numbers.forEach(num => {
           expect(elem.children.length).to.equal(num);
-          if (canPatchNativeAccessors && type !== 'host') {
-            expect(elem.__children.length).to.equal(num);
-          }
           elem.appendChild(document.createElement('div'));
         });
 
         numbers.reverse().forEach(num => {
           elem.removeChild(elem.lastChild);
           expect(elem.children.length).to.equal(num);
-          if (canPatchNativeAccessors && type !== 'host') {
-            expect(elem.__children.length).to.equal(num);
-          }
         });
       });
 
       it('should not count text nodes', () => {
         elem.appendChild(document.createTextNode('text'));
         expect(elem.children.length).to.equal(0);
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__children.length).to.equal(0);
-        }
+
         elem.appendChild(document.createTextNode('text'));
         expect(elem.children.length).to.equal(0);
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__children.length).to.equal(0);
-        }
 
         elem.removeChild(elem.lastChild);
         expect(elem.children.length).to.equal(0);
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__children.length).to.equal(0);
-        }
+
         elem.removeChild(elem.lastChild);
         expect(elem.children.length).to.equal(0);
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__children.length).to.equal(0);
-        }
       });
 
       it('should not count comment nodes', () => {
         elem.appendChild(document.createComment('comment'));
         expect(elem.children.length).to.equal(0);
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__children.length).to.equal(0);
-        }
+
         elem.appendChild(document.createComment('comment'));
         expect(elem.children.length).to.equal(0);
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__children.length).to.equal(0);
-        }
 
         elem.removeChild(elem.lastChild);
         expect(elem.children.length).to.equal(0);
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__children.length).to.equal(0);
-        }
+
         elem.removeChild(elem.lastChild);
         expect(elem.children.length).to.equal(0);
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__children.length).to.equal(0);
-        }
       });
     });
   }

--- a/test/unit/dom/firstChild.js
+++ b/test/unit/dom/firstChild.js
@@ -1,5 +1,3 @@
-import canPatchNativeAccessors from '../../../src/util/can-patch-native-accessors';
-
 describe('dom: firstChild', () => {
   function runTests(type) {
     describe(`${type}: `, () => {
@@ -37,56 +35,24 @@ describe('dom: firstChild', () => {
       it('should return null if there are no children', () => {
         elem.innerHTML = '';
         expect(elem.firstChild).to.equal(null);
-
-        if (canPatchNativeAccessors) {
-          if (type === 'host') {
-            expect(elem.__firstChild).to.equal(root);
-          } else {
-            expect(elem.__firstChild).to.equal(null);
-          }
-        }
       });
 
       it('should return correct element node from a parent with just one child', () => {
         const appended = document.createElement('test');
         elem.appendChild(appended);
         expect(elem.firstChild).to.equal(appended);
-
-        if (canPatchNativeAccessors) {
-          if (type === 'host') {
-            expect(elem.__firstChild).to.equal(root);
-          } else {
-            expect(elem.__firstChild).to.equal(appended);
-          }
-        }
       });
 
       it('should return correct text node from a parent with just one child', () => {
         const appended = document.createTextNode('text');
         elem.appendChild(appended);
         expect(elem.firstChild).to.equal(appended);
-
-        if (canPatchNativeAccessors) {
-          if (type === 'host') {
-            expect(elem.__firstChild).to.equal(root);
-          } else {
-            expect(elem.__firstChild).to.equal(appended);
-          }
-        }
       });
 
       it('should return correct comment node from a parent with just one child', () => {
         const appended = document.createComment('comment');
         elem.appendChild(appended);
         expect(elem.firstChild).to.equal(appended);
-
-        if (canPatchNativeAccessors) {
-          if (type === 'host') {
-            expect(elem.__firstChild).to.equal(root);
-          } else {
-            expect(elem.__firstChild).to.equal(appended);
-          }
-        }
       });
 
       it('should return correct element node from a parent with two or more children', () => {
@@ -95,14 +61,6 @@ describe('dom: firstChild', () => {
         elem.appendChild(document.createElement('test2'));
         elem.appendChild(document.createElement('test3'));
         expect(elem.firstChild).to.equal(appended);
-
-        if (canPatchNativeAccessors) {
-          if (type === 'host') {
-            expect(elem.__firstChild).to.equal(root);
-          } else {
-            expect(elem.__firstChild).to.equal(appended);
-          }
-        }
       });
 
       it('should return correct text node from a parent with two or more children', () => {
@@ -111,14 +69,6 @@ describe('dom: firstChild', () => {
         elem.appendChild(document.createElement('test2'));
         elem.appendChild(document.createElement('test3'));
         expect(elem.firstChild).to.equal(appended);
-
-        if (canPatchNativeAccessors) {
-          if (type === 'host') {
-            expect(elem.__firstChild).to.equal(root);
-          } else {
-            expect(elem.__firstChild).to.equal(appended);
-          }
-        }
       });
 
       it('should return correct comment node from a parent with two or more children', () => {
@@ -127,14 +77,6 @@ describe('dom: firstChild', () => {
         elem.appendChild(document.createElement('test2'));
         elem.appendChild(document.createElement('test3'));
         expect(elem.firstChild).to.equal(appended);
-
-        if (canPatchNativeAccessors) {
-          if (type === 'host') {
-            expect(elem.__firstChild).to.equal(root);
-          } else {
-            expect(elem.__firstChild).to.equal(appended);
-          }
-        }
       });
 
       it('should return firstChild in a complex tree', () => {
@@ -146,15 +88,6 @@ describe('dom: firstChild', () => {
 
         expect(elem.firstChild.firstChild).to.equal(child1);
         expect(elem.childNodes[1].firstChild.firstChild).to.equal(child2);
-
-        if (canPatchNativeAccessors) {
-          if (type === 'host') {
-            expect(elem.__firstChild.__firstChild).to.equal(slot);
-          } else {
-            expect(elem.__firstChild.__firstChild).to.equal(child1);
-            expect(elem.__childNodes[1].__firstChild.__firstChild).to.equal(child2);
-          }
-        }
       });
     });
   }

--- a/test/unit/dom/firstElementChild.js
+++ b/test/unit/dom/firstElementChild.js
@@ -1,5 +1,3 @@
-import canPatchNativeAccessors from '../../../src/util/can-patch-native-accessors';
-
 describe('dom: firstElementChild', () => {
   function runTests(type) {
     describe(`${type}: `, () => {
@@ -37,56 +35,24 @@ describe('dom: firstElementChild', () => {
       it('should return null if there are no children', () => {
         elem.innerHTML = '';
         expect(elem.firstElementChild).to.equal(null);
-
-        if (canPatchNativeAccessors) {
-          if (type === 'host') {
-            expect(elem.__firstElementChild).to.equal(root);
-          } else {
-            expect(elem.__firstElementChild).to.equal(null);
-          }
-        }
       });
 
       it('should return correct element node from a parent with just one child', () => {
         const appended = document.createElement('test');
         elem.appendChild(appended);
         expect(elem.firstElementChild).to.equal(appended);
-
-        if (canPatchNativeAccessors) {
-          if (type === 'host') {
-            expect(elem.__firstElementChild).to.equal(root);
-          } else {
-            expect(elem.__firstElementChild).to.equal(appended);
-          }
-        }
       });
 
       it('should NOT return text node from a parent with just one child', () => {
         const appended = document.createTextNode('text');
         elem.appendChild(appended);
         expect(elem.firstElementChild).to.equal(null);
-
-        if (canPatchNativeAccessors) {
-          if (type === 'host') {
-            expect(elem.__firstElementChild).to.equal(root);
-          } else {
-            expect(elem.__firstElementChild).to.equal(null);
-          }
-        }
       });
 
       it('should NOT return comment node from a parent with just one child', () => {
         const appended = document.createComment('comment');
         elem.appendChild(appended);
         expect(elem.firstElementChild).to.equal(null);
-
-        if (canPatchNativeAccessors) {
-          if (type === 'host') {
-            expect(elem.__firstElementChild).to.equal(root);
-          } else {
-            expect(elem.__firstElementChild).to.equal(null);
-          }
-        }
       });
 
       it('should return correct element node from a parent with two or more children', () => {
@@ -95,14 +61,6 @@ describe('dom: firstElementChild', () => {
         elem.appendChild(document.createElement('test2'));
         elem.appendChild(document.createElement('test3'));
         expect(elem.firstElementChild).to.equal(appended);
-
-        if (canPatchNativeAccessors) {
-          if (type === 'host') {
-            expect(elem.__firstElementChild).to.equal(root);
-          } else {
-            expect(elem.__firstElementChild).to.equal(appended);
-          }
-        }
       });
 
       it('should skip first text node from a parent with two or more children', () => {
@@ -112,14 +70,6 @@ describe('dom: firstElementChild', () => {
         elem.appendChild(elNode);
         elem.appendChild(document.createElement('test3'));
         expect(elem.firstElementChild).to.equal(elNode);
-
-        if (canPatchNativeAccessors) {
-          if (type === 'host') {
-            expect(elem.__firstElementChild).to.equal(root);
-          } else {
-            expect(elem.__firstElementChild).to.equal(elNode);
-          }
-        }
       });
 
       it('should skip first comment node from a parent with two or more children', () => {
@@ -129,14 +79,6 @@ describe('dom: firstElementChild', () => {
         elem.appendChild(elNode);
         elem.appendChild(document.createElement('test3'));
         expect(elem.firstElementChild).to.equal(elNode);
-
-        if (canPatchNativeAccessors) {
-          if (type === 'host') {
-            expect(elem.__firstElementChild).to.equal(root);
-          } else {
-            expect(elem.__firstElementChild).to.equal(elNode);
-          }
-        }
       });
 
       it('should return correct element node in a complex tree', () => {
@@ -148,15 +90,6 @@ describe('dom: firstElementChild', () => {
 
         expect(elem.firstElementChild.firstElementChild).to.equal(child1);
         expect(elem.childNodes[1].firstElementChild.firstElementChild).to.equal(child2);
-
-        if (canPatchNativeAccessors) {
-          if (type === 'host') {
-            expect(elem.__firstElementChild.__firstElementChild).to.equal(slot);
-          } else {
-            expect(elem.__firstElementChild.__firstElementChild).to.equal(child1);
-            expect(elem.__childNodes[1].__firstElementChild.__firstElementChild).to.equal(child2);
-          }
-        }
       });
     });
   }

--- a/test/unit/dom/hasChildNodes.js
+++ b/test/unit/dom/hasChildNodes.js
@@ -1,5 +1,3 @@
-import canPatchNativeAccessors from '../../../src/util/can-patch-native-accessors';
-
 describe('dom: hasChildNodes', () => {
   function runTests(type) {
     describe(`${type}: `, () => {
@@ -37,46 +35,26 @@ describe('dom: hasChildNodes', () => {
       it('should return false if there are no child nodes', () => {
         elem.innerHTML = '';
         expect(elem.hasChildNodes()).to.equal(false);
-
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__hasChildNodes()).to.equal(false);
-        }
       });
 
       it('should return true if there is one element child node', () => {
         elem.innerHTML = '<div></div>';
         expect(elem.hasChildNodes()).to.equal(true);
-
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__hasChildNodes()).to.equal(true);
-        }
       });
 
       it('should return true if there is one text child node', () => {
         elem.innerHTML = 'text';
         expect(elem.hasChildNodes()).to.equal(true);
-
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__hasChildNodes()).to.equal(true);
-        }
       });
 
       it('should return true if there is one comment child node', () => {
         elem.innerHTML = '<!--comment-->';
         expect(elem.hasChildNodes()).to.equal(true);
-
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__hasChildNodes()).to.equal(true);
-        }
       });
 
       it('should return true if there is more than one child node', () => {
         elem.innerHTML = '<div></div>text<div></div>';
         expect(elem.hasChildNodes()).to.equal(true);
-
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__hasChildNodes()).to.equal(true);
-        }
       });
 
       it('should return correct value in a complex tree', () => {
@@ -87,15 +65,6 @@ describe('dom: hasChildNodes', () => {
         expect(elem.childNodes[1].childNodes[0].hasChildNodes()).to.equal(false);
         expect(elem.childNodes[1].childNodes[1].hasChildNodes()).to.equal(true);
         expect(elem.lastChild.hasChildNodes()).to.equal(false);
-
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__hasChildNodes()).to.equal(true);
-          expect(elem.__firstChild.__hasChildNodes()).to.equal(false);
-          expect(elem.__childNodes[1].__hasChildNodes()).to.equal(true);
-          expect(elem.__childNodes[1].__childNodes[0].__hasChildNodes()).to.equal(false);
-          expect(elem.__childNodes[1].__childNodes[1].__hasChildNodes()).to.equal(true);
-          expect(elem.__lastChild.__hasChildNodes()).to.equal(false);
-        }
       });
     });
   }

--- a/test/unit/dom/insertBefore.js
+++ b/test/unit/dom/insertBefore.js
@@ -41,7 +41,7 @@ describe('dom: insertBefore', () => {
 
       it('should return the inserted node', () => {
         const inserted = document.createElement('div');
-        const changedElem = elem.insertBefore(inserted);
+        const changedElem = elem.insertBefore(inserted, null);
         expect(changedElem).not.to.equal(undefined);
         expect(changedElem).to.equal(inserted);
       });
@@ -49,7 +49,7 @@ describe('dom: insertBefore', () => {
       it('should append node if referenceNode is null', () => {
         elem.innerHTML = '<div></div><div></div>';
         const inserted = document.createElement('test');
-        elem.insertBefore(inserted);
+        elem.insertBefore(inserted, null);
 
         expect(elem.innerHTML).to.equal('<div></div><div></div><test></test>');
         expect(elem.childNodes[2]).to.equal(inserted);
@@ -61,7 +61,7 @@ describe('dom: insertBefore', () => {
 
       it('should insert an element node to a parent with no children', () => {
         const inserted = document.createElement('test');
-        elem.insertBefore(inserted);
+        elem.insertBefore(inserted, null);
 
         expect(elem.innerHTML).to.equal('<test></test>');
         expect(elem.childNodes[0]).to.equal(inserted);
@@ -73,7 +73,7 @@ describe('dom: insertBefore', () => {
 
       it('should insert a text node to a parent with no children', () => {
         const inserted = document.createTextNode('text');
-        elem.insertBefore(inserted);
+        elem.insertBefore(inserted, null);
 
         expect(elem.innerHTML).to.equal('text');
         expect(elem.childNodes[0]).to.equal(inserted);
@@ -85,7 +85,7 @@ describe('dom: insertBefore', () => {
 
       it('should insert a comment node to a parent with no children', () => {
         const inserted = document.createComment('comment');
-        elem.insertBefore(inserted);
+        elem.insertBefore(inserted, null);
 
         expect(elem.innerHTML).to.equal('<!--comment-->');
         expect(elem.childNodes[0]).to.equal(inserted);

--- a/test/unit/dom/lastChild.js
+++ b/test/unit/dom/lastChild.js
@@ -1,8 +1,6 @@
-import canPatchNativeAccessors from '../../../src/util/can-patch-native-accessors';
-
 describe('dom: lastChild', () => {
   function runTests(type) {
-    describe(`${type}: `, () => {
+    describe(`${type}:`, () => {
       let host;
       let root;
       let slot;
@@ -37,40 +35,24 @@ describe('dom: lastChild', () => {
       it('should return null if there are no children', () => {
         elem.innerHTML = '';
         expect(elem.lastChild).to.equal(null);
-
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__lastChild).to.equal(null);
-        }
       });
 
       it('should return correct element node from a parent with just one child', () => {
         const appended = document.createElement('test');
         elem.appendChild(appended);
         expect(elem.lastChild).to.equal(appended);
-
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__lastChild).to.equal(appended);
-        }
       });
 
       it('should return correct text node from a parent with just one child', () => {
         const appended = document.createTextNode('text');
         elem.appendChild(appended);
         expect(elem.lastChild).to.equal(appended);
-
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__lastChild).to.equal(appended);
-        }
       });
 
       it('should return correct comment node from a parent with just one child', () => {
         const appended = document.createComment('comment');
         elem.appendChild(appended);
         expect(elem.lastChild).to.equal(appended);
-
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__lastChild).to.equal(appended);
-        }
       });
 
       it('should return correct element node from a parent with two or more children', () => {
@@ -78,12 +60,7 @@ describe('dom: lastChild', () => {
         elem.appendChild(document.createElement('test2'));
         elem.appendChild(document.createElement('test3'));
         elem.appendChild(appended);
-
         expect(elem.lastChild).to.equal(appended);
-
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__lastChild).to.equal(appended);
-        }
       });
 
       it('should return correct text node from a parent with two or more children', () => {
@@ -92,10 +69,6 @@ describe('dom: lastChild', () => {
         elem.appendChild(document.createElement('test3'));
         elem.appendChild(appended);
         expect(elem.lastChild).to.equal(appended);
-
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__lastChild).to.equal(appended);
-        }
       });
 
       it('should return correct comment node from a parent with two or more children', () => {
@@ -104,10 +77,6 @@ describe('dom: lastChild', () => {
         elem.appendChild(document.createElement('test3'));
         elem.appendChild(appended);
         expect(elem.lastChild).to.equal(appended);
-
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__lastChild).to.equal(appended);
-        }
       });
 
       it('should return lastChild in a complex tree', () => {
@@ -116,14 +85,8 @@ describe('dom: lastChild', () => {
         elem.innerHTML = '<div1></div1><div2><div3></div3></div2><div4></div4>';
         elem.childNodes[2].appendChild(child1);
         elem.childNodes[1].childNodes[0].appendChild(child2);
-
         expect(elem.lastChild.lastChild).to.equal(child1);
         expect(elem.childNodes[1].lastChild.lastChild).to.equal(child2);
-
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__lastChild.__lastChild).to.equal(child1);
-          expect(elem.__childNodes[1].__lastChild.__lastChild).to.equal(child2);
-        }
       });
     });
   }

--- a/test/unit/dom/lastElementChild.js
+++ b/test/unit/dom/lastElementChild.js
@@ -1,5 +1,3 @@
-import canPatchNativeAccessors from '../../../src/util/can-patch-native-accessors';
-
 describe('dom: lastElementChild', () => {
   function runTests(type) {
     describe(`${type}: `, () => {
@@ -37,40 +35,24 @@ describe('dom: lastElementChild', () => {
       it('should return null if there are no children', () => {
         elem.innerHTML = '';
         expect(elem.lastElementChild).to.equal(null);
-
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__lastElementChild).to.equal(null);
-        }
       });
 
       it('should return correct element node from a parent with just one child', () => {
         const appended = document.createElement('test');
         elem.appendChild(appended);
         expect(elem.lastElementChild).to.equal(appended);
-
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__lastElementChild).to.equal(appended);
-        }
       });
 
       it('should NOT return text node from a parent with just one child', () => {
         const appended = document.createTextNode('text');
         elem.appendChild(appended);
         expect(elem.lastElementChild).to.equal(null);
-
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__lastElementChild).to.equal(null);
-        }
       });
 
       it('should NOT return comment node from a parent with just one child', () => {
         const appended = document.createComment('comment');
         elem.appendChild(appended);
         expect(elem.lastElementChild).to.equal(null);
-
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__lastElementChild).to.equal(null);
-        }
       });
 
       it('should return correct element node from a parent with two or more children', () => {
@@ -78,12 +60,7 @@ describe('dom: lastElementChild', () => {
         elem.appendChild(document.createElement('test2'));
         elem.appendChild(document.createElement('test3'));
         elem.appendChild(appended);
-
         expect(elem.lastElementChild).to.equal(appended);
-
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__lastElementChild).to.equal(appended);
-        }
       });
 
       it('should NOT return text node from a parent with two or more children', () => {
@@ -93,10 +70,6 @@ describe('dom: lastElementChild', () => {
         elem.appendChild(appended2);
         elem.appendChild(appended1);
         expect(elem.lastElementChild).to.equal(appended2);
-
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__lastElementChild).to.equal(appended2);
-        }
       });
 
       it('should NOT return comment node from a parent with two or more children', () => {
@@ -106,10 +79,6 @@ describe('dom: lastElementChild', () => {
         elem.appendChild(appended2);
         elem.appendChild(appended1);
         expect(elem.lastElementChild).to.equal(appended2);
-
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__lastElementChild).to.equal(appended2);
-        }
       });
 
       it('should return lastElementChild in a complex tree', () => {
@@ -118,14 +87,8 @@ describe('dom: lastElementChild', () => {
         elem.innerHTML = '<div1></div1><div2><div3></div3></div2><div4></div4>';
         elem.childNodes[2].appendChild(child1);
         elem.childNodes[1].childNodes[0].appendChild(child2);
-
         expect(elem.lastElementChild.lastElementChild).to.equal(child1);
         expect(elem.childNodes[1].lastElementChild.lastElementChild).to.equal(child2);
-
-        if (canPatchNativeAccessors && type !== 'host') {
-          expect(elem.__lastElementChild.__lastElementChild).to.equal(child1);
-          expect(elem.__childNodes[1].__lastElementChild.__lastElementChild).to.equal(child2);
-        }
       });
     });
   }

--- a/test/unit/dom/outerHTML.js
+++ b/test/unit/dom/outerHTML.js
@@ -1,6 +1,18 @@
-import canPatchNativeAccessors from '../../../src/util/can-patch-native-accessors';
+import { shadowDomV0 } from '../../../src/util/support';
 
 describe('dom: outerHTML', () => {
+  // This is so that it goes through any possible innerHTML massaging. For
+  // example, this is necessary when upgrading native v0 to behave like v1.
+  function html(str) {
+    const div = document.createElement('div');
+    div.innerHTML = str;
+    return div.innerHTML;
+  }
+
+  function compare(src, dst) {
+    expect(src.outerHTML).to.equal(shadowDomV0 ? html(dst) : dst);
+  }
+
   function runTests(type) {
     describe(`${type}: `, () => {
       let host;
@@ -25,10 +37,6 @@ describe('dom: outerHTML', () => {
         case 'slot':
           elem = slot;
           break;
-        case 'root':
-          root.innerHTML = '';
-          elem = root;
-          break;
         default:
           elem = host;
         }
@@ -37,80 +45,36 @@ describe('dom: outerHTML', () => {
       it('should get a proper value from a node with one element child', () => {
         elem.innerHTML = '<test></test>';
         if (type === 'host' || type === 'div') {
-          expect(elem.outerHTML).to.equal('<div><test></test></div>');
-          if (canPatchNativeAccessors && type === 'div') {
-            expect(elem.__outerHTML).to.equal('<div><test></test></div>');
-          }
+          compare(elem, '<div><test></test></div>');
         } else if (type === 'slot') {
-          expect(elem.outerHTML).to.equal('<slot><test></test></slot>');
-          if (canPatchNativeAccessors) {
-            expect(elem.__outerHTML).to.equal('<slot><test></test></slot>');
-          }
-        } else if (type === 'root') {
-          expect(elem.outerHTML).to.equal('<_shadow_root_><test></test></_shadow_root_>');
-          if (canPatchNativeAccessors) {
-            expect(elem.__outerHTML).to.equal('<_shadow_root_><test></test></_shadow_root_>');
-          }
+          compare(elem, '<slot><test></test></slot>');
         }
       });
 
       it('should get a proper value from a node with one text child', () => {
         elem.innerHTML = 'text';
         if (type === 'host' || type === 'div') {
-          expect(elem.outerHTML).to.equal('<div>text</div>');
-          if (canPatchNativeAccessors && type === 'div') {
-            expect(elem.__outerHTML).to.equal('<div>text</div>');
-          }
+          compare(elem, '<div>text</div>');
         } else if (type === 'slot') {
-          expect(elem.outerHTML).to.equal('<slot>text</slot>');
-          if (canPatchNativeAccessors) {
-            expect(elem.__outerHTML).to.equal('<slot>text</slot>');
-          }
-        } else if (type === 'root') {
-          expect(elem.outerHTML).to.equal('<_shadow_root_>text</_shadow_root_>');
-          if (canPatchNativeAccessors) {
-            expect(elem.__outerHTML).to.equal('<_shadow_root_>text</_shadow_root_>');
-          }
+          compare(elem, '<slot>text</slot>');
         }
       });
 
       it('should get a proper value from a node with one comment child', () => {
         elem.innerHTML = '<!--comment-->';
         if (type === 'host' || type === 'div') {
-          expect(elem.outerHTML).to.equal('<div><!--comment--></div>');
-          if (canPatchNativeAccessors && type === 'div') {
-            expect(elem.__outerHTML).to.equal('<div><!--comment--></div>');
-          }
+          compare(elem, '<div><!--comment--></div>');
         } else if (type === 'slot') {
-          expect(elem.outerHTML).to.equal('<slot><!--comment--></slot>');
-          if (canPatchNativeAccessors) {
-            expect(elem.__outerHTML).to.equal('<slot><!--comment--></slot>');
-          }
-        } else if (type === 'root') {
-          expect(elem.outerHTML).to.equal('<_shadow_root_><!--comment--></_shadow_root_>');
-          if (canPatchNativeAccessors) {
-            expect(elem.__outerHTML).to.equal('<_shadow_root_><!--comment--></_shadow_root_>');
-          }
+          compare(elem, '<slot><!--comment--></slot>');
         }
       });
 
       it('should get a proper value from a node with two or more children', () => {
         elem.innerHTML = '<test></test><test2>text</test2><!--comment-->';
         if (type === 'host' || type === 'div') {
-          expect(elem.outerHTML).to.equal('<div><test></test><test2>text</test2><!--comment--></div>');
-          if (canPatchNativeAccessors && type === 'div') {
-            expect(elem.__outerHTML).to.equal('<div><test></test><test2>text</test2><!--comment--></div>');
-          }
+          compare(elem, '<div><test></test><test2>text</test2><!--comment--></div>');
         } else if (type === 'slot') {
-          expect(elem.outerHTML).to.equal('<slot><test></test><test2>text</test2><!--comment--></slot>');
-          if (canPatchNativeAccessors) {
-            expect(elem.__outerHTML).to.equal('<slot><test></test><test2>text</test2><!--comment--></slot>');
-          }
-        } else if (type === 'root') {
-          expect(elem.outerHTML).to.equal('<_shadow_root_><test></test><test2>text</test2><!--comment--></_shadow_root_>');
-          if (canPatchNativeAccessors) {
-            expect(elem.__outerHTML).to.equal('<_shadow_root_><test></test><test2>text</test2><!--comment--></_shadow_root_>');
-          }
+          compare(elem, '<slot><test></test><test2>text</test2><!--comment--></slot>');
         }
       });
 
@@ -118,31 +82,10 @@ describe('dom: outerHTML', () => {
         elem.innerHTML = '<div1><div2></div2><div3></div3></div1>';
         elem.childNodes[0].childNodes[0].outerHTML = '<div4></div4>';
         expect(elem.innerHTML).to.equal('<div1><div4></div4><div3></div3></div1>');
-        if (type !== 'host') {
-          if (canPatchNativeAccessors) {
-            expect(elem.__innerHTML).to.equal('<div1><div4></div4><div3></div3></div1>');
-          }
-        }
 
         elem.innerHTML = '<div1><div2></div2><div3></div3></div1>';
         elem.childNodes[0].outerHTML = '<div4></div4>';
         expect(elem.innerHTML).to.equal('<div4></div4>');
-
-        if (type !== 'host') {
-          if (canPatchNativeAccessors) {
-            expect(elem.__innerHTML).to.equal('<div4></div4>');
-          }
-        }
-
-        if (type === 'root') {
-          elem.innerHTML = '<div></div>';
-          // we can't change root with this, so nothing should happen
-          elem.outerHTML = '<p></p>';
-          expect(elem.outerHTML).to.equal('<_shadow_root_><div></div></_shadow_root_>');
-          if (canPatchNativeAccessors) {
-            expect(elem.__outerHTML).to.equal('<_shadow_root_><div></div></_shadow_root_>');
-          }
-        }
       });
     });
   }
@@ -150,5 +93,4 @@ describe('dom: outerHTML', () => {
   runTests('div');
   runTests('slot');
   runTests('host');
-  runTests('root');
 });

--- a/test/unit/dom/removeChild.js
+++ b/test/unit/dom/removeChild.js
@@ -1,5 +1,3 @@
-import canPatchNativeAccessors from '../../../src/util/can-patch-native-accessors';
-
 describe('dom: removeChild', () => {
   function runTests(type) {
     describe(`${type}: `, () => {
@@ -61,11 +59,7 @@ describe('dom: removeChild', () => {
         const removed = document.createElement('div');
         elem.appendChild(removed);
         elem.removeChild(removed);
-
         expect(removed.parentNode).to.be.equal(null);
-        if (canPatchNativeAccessors) {
-          expect(removed.__parentNode).to.be.equal(null);
-        }
       });
 
       it('should remove a single element node', () => {

--- a/test/unit/dom/textContent.js
+++ b/test/unit/dom/textContent.js
@@ -1,6 +1,4 @@
-import canPatchNativeAccessors from '../../../src/util/can-patch-native-accessors';
-
-describe('dom: lastChild', () => {
+describe('dom: textContent', () => {
   function runTests(type) {
     describe(`${type}: `, () => {
       let host;
@@ -39,12 +37,6 @@ describe('dom: lastChild', () => {
         expect(elem.textContent).to.equal('<test />');
         expect(elem.innerHTML).to.equal('&lt;test /&gt;');
         expect(elem.childNodes.length).to.equal(1);
-
-        if (type !== 'host' && canPatchNativeAccessors) {
-          expect(elem.__textContent).to.equal('<test />');
-          expect(elem.__innerHTML).to.equal('&lt;test /&gt;');
-          expect(elem.__childNodes.length).to.equal(1);
-        }
       });
 
       it('should be set correctly to a node with children', () => {
@@ -53,67 +45,33 @@ describe('dom: lastChild', () => {
         expect(elem.textContent).to.equal('<test />');
         expect(elem.innerHTML).to.equal('&lt;test /&gt;');
         expect(elem.childNodes.length).to.equal(1);
-
-        if (type !== 'host' && canPatchNativeAccessors) {
-          expect(elem.__textContent).to.equal('<test />');
-          expect(elem.__innerHTML).to.equal('&lt;test /&gt;');
-          expect(elem.__childNodes.length).to.equal(1);
-        }
       });
 
       it('should always get the correct text value', () => {
         elem.innerHTML = '';
         expect(elem.textContent).to.equal('');
 
-        if (type !== 'host' && canPatchNativeAccessors) {
-          expect(elem.__textContent).to.equal('');
-        }
-
         elem.innerHTML = '<div></div>';
         expect(elem.textContent).to.equal('');
-
-        if (type !== 'host' && canPatchNativeAccessors) {
-          expect(elem.__textContent).to.equal('');
-        }
 
         elem.innerHTML = '<div>text</div>';
         expect(elem.textContent).to.equal('text');
 
-        if (type !== 'host' && canPatchNativeAccessors) {
-          expect(elem.__textContent).to.equal('text');
-        }
-
         elem.innerHTML = 'outside <div>text</div> outside ';
         expect(elem.textContent).to.equal('outside text outside ');
 
-        if (type !== 'host' && canPatchNativeAccessors) {
-          expect(elem.__textContent).to.equal('outside text outside ');
-        }
-
         elem.innerHTML = 'outside <div>text <div>deep inside</div> <div>another</div></div> outside ';
         expect(elem.textContent).to.equal('outside text deep inside another outside ');
-
-        if (type !== 'host' && canPatchNativeAccessors) {
-          expect(elem.__textContent).to.equal('outside text deep inside another outside ');
-        }
       });
 
       it('should not return comments', () => {
         elem.innerHTML = '<!-- comment -->';
         expect(elem.textContent).to.equal('');
-
-        if (type !== 'host' && canPatchNativeAccessors) {
-          expect(elem.__textContent).to.equal('');
-        }
       });
 
       it('setting to \'\' does not affect textContent', () => {
         elem.textContent = '';
         expect(elem.innerHTML).to.equal('');
-
-        if (type !== 'host' && canPatchNativeAccessors) {
-          expect(elem.__innerHTML).to.equal('');
-        }
       });
     });
   }

--- a/test/unit/shadow/polyfill.js
+++ b/test/unit/shadow/polyfill.js
@@ -1,4 +1,5 @@
 import '../../../src/index';
+import { shadowDomV0 } from '../../../src/util/support';
 import create from '../../lib/create';
 import canPatchNativeAccessors from '../../../src/util/can-patch-native-accessors';
 
@@ -27,20 +28,20 @@ describe('shadow/polyfill', () => {
     expect(host.shadowRoot).to.equal(null);
   });
 
-  it('polyfillShadowRootTagName: [default="_shadow_root_"]', () => {
+  shadowDomV0 || it('polyfillShadowRootTagName: [default="_shadow_root_"]', () => {
     const host = create('div');
     const root = host.attachShadow({ mode: 'open' });
     expect(root.tagName).to.equal('_SHADOW_ROOT_');
   });
 
-  it('polyfillShadowRootTagName: "test-ing"', () => {
+  shadowDomV0 || it('polyfillShadowRootTagName: "test-ing"', () => {
     const host = create('div');
     const root = host.attachShadow({ mode: 'open', polyfillShadowRootTagName: 'test-ing' });
     expect(root.tagName).to.equal('TEST-ING');
   });
 
   if (canPatchNativeAccessors) {
-    it('proper node removal', () => {
+    shadowDomV0 || it('proper node removal', () => {
       const host = create('div');
       host.appendChild(create('div'));
       host.appendChild(create('div'));

--- a/test/unit/shadow/polyfill.js
+++ b/test/unit/shadow/polyfill.js
@@ -28,30 +28,32 @@ describe('shadow/polyfill', () => {
     expect(host.shadowRoot).to.equal(null);
   });
 
-  shadowDomV0 || it('polyfillShadowRootTagName: [default="_shadow_root_"]', () => {
-    const host = create('div');
-    const root = host.attachShadow({ mode: 'open' });
-    expect(root.tagName).to.equal('_SHADOW_ROOT_');
-  });
-
-  shadowDomV0 || it('polyfillShadowRootTagName: "test-ing"', () => {
-    const host = create('div');
-    const root = host.attachShadow({ mode: 'open', polyfillShadowRootTagName: 'test-ing' });
-    expect(root.tagName).to.equal('TEST-ING');
-  });
-
-  if (canPatchNativeAccessors) {
-    shadowDomV0 || it('proper node removal', () => {
+  if (!shadowDomV0) {
+    it('polyfillShadowRootTagName: [default="_shadow_root_"]', () => {
       const host = create('div');
-      host.appendChild(create('div'));
-      host.appendChild(create('div'));
-      host.appendChild(create('div'));
-      host.appendChild(create('div'));
-      host.attachShadow({ mode: 'open' });
-
-      expect(host.__childNodes.length).to.equal(1);
-      expect(host.__childNodes[0].tagName).to.equal('_SHADOW_ROOT_');
+      const root = host.attachShadow({ mode: 'open' });
+      expect(root.tagName).to.equal('_SHADOW_ROOT_');
     });
+
+    it('polyfillShadowRootTagName: "test-ing"', () => {
+      const host = create('div');
+      const root = host.attachShadow({ mode: 'open', polyfillShadowRootTagName: 'test-ing' });
+      expect(root.tagName).to.equal('TEST-ING');
+    });
+
+    if (canPatchNativeAccessors) {
+      it('proper node removal', () => {
+        const host = create('div');
+        host.appendChild(create('div'));
+        host.appendChild(create('div'));
+        host.appendChild(create('div'));
+        host.appendChild(create('div'));
+        host.attachShadow({ mode: 'open' });
+
+        expect(host.__childNodes.length).to.equal(1);
+        expect(host.__childNodes[0].tagName).to.equal('_SHADOW_ROOT_');
+      });
+    }
   }
 
   it('polyfilled properties with value should be writable', () => {

--- a/test/unit/slot/distribution.js
+++ b/test/unit/slot/distribution.js
@@ -56,22 +56,23 @@ describe('slot/distribution', () => {
 
   describe('distributes to the slot that is owned by the current shadow root, not slots of descendant shadow roots', () => {
     it('for default slots', () => {
-      const host1 = document.createElement('host1');
-      const host2 = document.createElement('host2');
+      const host1 = document.createElement('host-1');
+      const host2 = document.createElement('host-2');
       const slot1 = document.createElement('slot');
       const slot2 = document.createElement('slot');
       const test = document.createTextNode('test');
 
       // Host2 must be set up and then added to host1's shadow root so that
       // host1 tries to slot the test content into host2's slot2 instead of
-      // host1's slot1.
-      host2.appendChild(slot1);
-      host2.attachShadow({ mode: 'open' });
-      host2.shadowRoot.appendChild(slot2);
+      // host1's slot1. Order of setup doesn't matter here.
 
       host1.appendChild(test);
       host1.attachShadow({ mode: 'open' });
       host1.shadowRoot.appendChild(host2);
+
+      host2.appendChild(slot1);
+      host2.attachShadow({ mode: 'open' });
+      host2.shadowRoot.appendChild(slot2);
 
       expect(slot1.assignedNodes().length).to.equal(1);
       expect(slot1.assignedNodes()[0]).to.equal(test);

--- a/test/unit/slot/fallback-content.js
+++ b/test/unit/slot/fallback-content.js
@@ -1,3 +1,4 @@
+import { shadowDomV0 } from '../../../src/util/support';
 import create from '../../lib/create';
 
 describe('fallback-content', () => {
@@ -5,6 +6,11 @@ describe('fallback-content', () => {
   let root;
   let slot;
   let fallback;
+
+  // We don't need to run these tests at all against v0.
+  if (shadowDomV0) {
+    return;
+  }
 
   beforeEach(() => {
     host = create('div');

--- a/test/unit/slot/polyfill.js
+++ b/test/unit/slot/polyfill.js
@@ -95,8 +95,10 @@ describe('slot/polyfill', () => {
     host.appendChild(document.createTextNode(' '));
     host.appendChild(document.createTextNode('\n'));
     host.appendChild(document.createTextNode('testing'));
-    expect(slot2.assignedNodes().length).to.equal(2);
+    expect(slot2.assignedNodes().length).to.equal(4);
     expect(slot2.assignedNodes()[0].textContent).to.equal('');
-    expect(slot2.assignedNodes()[1].textContent).to.equal('testing');
+    expect(slot2.assignedNodes()[1].textContent).to.equal(' ');
+    expect(slot2.assignedNodes()[2].textContent).to.equal('\n');
+    expect(slot2.assignedNodes()[3].textContent).to.equal('testing');
   });
 });


### PR DESCRIPTION
BREAKING CHANGE: v0 and v1 both allow whitespace of all kinds, so this has been relaxed. Implements
#108.
