### PR TITLE
fix: Fix innerHTML get to not escape text if a decendant of a certain element types

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -608,10 +608,10 @@ const members = {
       let innerHTML = '';
 
       const getHtmlNodeOuterHtml = (node) => node.outerHTML;
-      const getOuterHtmlByNodeType = {
-        1: getHtmlNodeOuterHtml,
-        8: getCommentNodeOuterHtml,
-      };
+      const getOuterHtmlByNodeType = {};
+      getOuterHtmlByNodeType[Node.ELEMENT_NODE] = getHtmlNodeOuterHtml;
+      getOuterHtmlByNodeType[Node.COMMENT_NODE] = getCommentNodeOuterHtml;
+
       // Text nodes with these ancestors should be treated as raw text
       // See section 8.4 of
       // https://www.w3.org/TR/2008/WD-html5-20080610/serializing.html#html-fragment
@@ -628,10 +628,10 @@ const members = {
 
       eachChildNode(this, node => {
         let getOuterHtml;
-        if (node.nodeType === 3) {
+        if (node.nodeType === Node.TEXT_NODE) {
           let parentNode = node.parentNode;
           while (parentNode) {
-            if (parentNode.nodeType === 1 && // only for elements
+            if (parentNode.nodeType === Node.ELEMENT_NODE &&
                 parentNode.nodeName.toLowerCase() in rawTextNodeAncestors) {
               getOuterHtml = getRawTextContent;
               break;

--- a/src/index.js
+++ b/src/index.js
@@ -615,27 +615,28 @@ const members = {
       // Text nodes with these ancestors should be treated as raw text
       // See section 8.4 of
       // https://www.w3.org/TR/2008/WD-html5-20080610/serializing.html#html-fragment
-      const rawTextNodeAncestors = new Set([
-        'style',
-        'script',
-        'xmp',
-        'iframe',
-        'noembed',
-        'noframes',
-        'noscript',
-        'plaintext',
-      ]);
+      const rawTextNodeAncestors = {
+        style: true,
+        script: true,
+        xmp: true,
+        iframe: true,
+        noembed: true,
+        noframes: true,
+        noscript: true,
+        plaintext: true,
+      };
 
       eachChildNode(this, node => {
         let getOuterHtml;
         if (node.nodeType === 3) {
-          let parentElement = node.parentElement;
-          while (parentElement) {
-            if (rawTextNodeAncestors.has(parentElement.nodeName.toLowerCase())) {
+          let parentNode = node.parentNode;
+          while (parentNode) {
+            if (parentNode.nodeType === 1 && // only for elements
+                parentNode.nodeName.toLowerCase() in rawTextNodeAncestors) {
               getOuterHtml = getRawTextContent;
               break;
             }
-            parentElement = parentElement.parentElement;
+            parentNode = parentNode.parentNode;
           }
           if (!getOuterHtml) {
             getOuterHtml = getEscapedTextContent;

--- a/src/index.js
+++ b/src/index.js
@@ -632,12 +632,12 @@ const members = {
           node.nodeName.toLowerCase() in rawTextNodeNames;
       }
 
-      const isCommonNodeRawText = isRawTextNode(this);
+      const isParentNodeRawText = isRawTextNode(this);
 
       eachChildNode(this, node => {
         let getOuterHtml;
         if (node.nodeType === Node.TEXT_NODE) {
-          if (isCommonNodeRawText || isRawTextNode(node)) {
+          if (isParentNodeRawText) {
             getOuterHtml = getRawTextContent;
           } else {
             getOuterHtml = getEscapedTextContent;

--- a/src/util/get-raw-text-content.js
+++ b/src/util/get-raw-text-content.js
@@ -1,0 +1,7 @@
+/**
+ * @param {TextNode}
+ * @returns {string}
+ */
+export default function getRawTextContent(textNode) {
+  return textNode.textContent;
+}

--- a/test/unit/dom/innerHTML.js
+++ b/test/unit/dom/innerHTML.js
@@ -111,21 +111,6 @@ describe('dom: innerHTML', () => {
         }
       });
 
-      it('created text nodes in noscript do not get escaped when being appended', () => {
-        const script = document.createElement('noscript');
-        const text = document.createTextNode('foo & <b>bar</b>');
-        const expectedInnerHtml = '<noscript>foo & <b>bar</b></noscript>';
-
-        script.appendChild(text);
-        elem.appendChild(script);
-        expect(elem.innerHTML).to.equal(expectedInnerHtml);
-        expect(elem.childNodes.length).to.equal(1);
-
-        if (type === 'host') {
-          expect(slot.assignedNodes().length).to.equal(1);
-        }
-      });
-
       it('innerHTML handles non text / html / comment nodes', () => {
         expect(elem.innerHTML).to.equal('');
         const processingInstruction = '<?xml-stylesheet href="mycss.css" type="text/css"?>';

--- a/test/unit/dom/innerHTML.js
+++ b/test/unit/dom/innerHTML.js
@@ -111,6 +111,21 @@ describe('dom: innerHTML', () => {
         }
       });
 
+      it('created text nodes in noscript do not get escaped when being appended', () => {
+        const script = document.createElement('noscript');
+        const text = document.createTextNode('foo & <b>bar</b>');
+        const expectedInnerHtml = '<noscript>foo & <b>bar</b></noscript>';
+
+        script.appendChild(text);
+        elem.appendChild(script);
+        expect(elem.innerHTML).to.equal(expectedInnerHtml);
+        expect(elem.childNodes.length).to.equal(1);
+
+        if (type === 'host') {
+          expect(slot.assignedNodes().length).to.equal(1);
+        }
+      });
+
       it('innerHTML handles non text / html / comment nodes', () => {
         expect(elem.innerHTML).to.equal('');
         const processingInstruction = '<?xml-stylesheet href="mycss.css" type="text/css"?>';

--- a/test/unit/dom/innerHTML.js
+++ b/test/unit/dom/innerHTML.js
@@ -96,6 +96,21 @@ describe('dom: innerHTML', () => {
         }
       });
 
+      it('created text nodes in scripts do not get escaped when being appended', () => {
+        const script = document.createElement('script');
+        const text = document.createTextNode('foo & <b>bar</b>');
+        const expectedInnerHtml = '<script>foo & <b>bar</b></script>';
+
+        script.appendChild(text);
+        elem.appendChild(script);
+        expect(elem.innerHTML).to.equal(expectedInnerHtml);
+        expect(elem.childNodes.length).to.equal(1);
+
+        if (type === 'host') {
+          expect(slot.assignedNodes().length).to.equal(1);
+        }
+      });
+
       it('innerHTML handles non text / html / comment nodes', () => {
         expect(elem.innerHTML).to.equal('');
         const processingInstruction = '<?xml-stylesheet href="mycss.css" type="text/css"?>';


### PR DESCRIPTION
Text nodes with particular ancestors (e.g. script, and style) should be treated as raw text when returning the value of innerHTML.

See section 8.4 of https://www.w3.org/TR/2008/WD-html5-20080610/serializing.html#html-fragment
