### PR TITLE
fix: force Safari to update its childNodes when doing appendChild

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_script:
 script:
   - sk-bundle
   - if [ "${TRAVIS_SECURE_ENV_VARS}" = "true" ]; then
-    npm test -- --browserstack;
+    npm test -- --all;
     else
     npm test -- --browsers Firefox;
     fi

--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
     "birdpoo": "0.0.2",
     "eslint": "^3.2.2",
     "eslint-plugin-react": "^6.0.0",
-    "precommit-hook": "^3.0.0",
-    "skatejs-build": "^7.3.0"
+    "skatejs-build": "9.x"
   },
   "dependencies": {
     "custom-event-polyfill": "^0.3.0",
@@ -51,8 +50,5 @@
       "path": "cz-conventional-changelog"
     }
   },
-  "pre-commit": [
-    "lint"
-  ],
   "version": "0.2.0"
 }

--- a/src/v1/index.js
+++ b/src/v1/index.js
@@ -395,6 +395,11 @@ function appendChildOrInsertBefore(host, newNode, refNode) {
     }
   }
 
+  // safari doesn't update its children properly for some reason, so it needs a little push
+  if (!canPatchNativeAccessors && parentNode) {
+    parentNode.removeChild(newNode);
+  }
+
   if (nodeType === 'node') {
     if (canPatchNativeAccessors) {
       nodeToParentNodeMap.set(newNode, host);

--- a/test/unit/dom/appendChild.js
+++ b/test/unit/dom/appendChild.js
@@ -200,6 +200,18 @@ describe('dom: appendChild', () => {
           expect(slot.assignedNodes().length).to.equal(3);
         }
       });
+
+      it('should remove appended node from the previous parent', () => {
+        const parent = document.createElement('div');
+        parent.appendChild(document.createElement('span'));
+        elem.appendChild(parent.firstChild);
+        expect(elem.childNodes.length).to.equal(1);
+        expect(parent.childNodes.length).to.equal(0);
+
+        if (type === 'host') {
+          expect(slot.assignedNodes().length).to.equal(1);
+        }
+      });
     });
   }
 


### PR DESCRIPTION
Safari doesn't properly update childNodes of a parent node after a node has been appended to a different node 

Solves #118
